### PR TITLE
docs: add cross-package pointer to austraits-meta

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,25 +1,9 @@
-# austraits-api — agent guide
+# CLAUDE.md
 
-> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
-> context. Add austraits-api-specific architecture, build/test commands, and gotchas below.
+This repo keeps its agent & contributor guidance in **[`AGENTS.md`](../AGENTS.md)** so the same
+content is tool-agnostic and shared across every agent.
 
-## Cross-package context
+**👉 Read [`AGENTS.md`](../AGENTS.md)** for repo-local orientation (architecture, build & test,
+gotchas) and the AusTraits-family cross-package pointer.
 
-`austraits-api` is part of the **AusTraits family**. Cross-package concerns are documented
-centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
-don't restate them here, read them there:
-
-- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
-  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
-  rules, gotchas.
-- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
-  machine-readable package graph + artifacts.
-- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
-  label taxonomy, board #9 conventions, release playbooks, triage.
-
-> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
-> the actual repos.
-
-## Package-local guidance (TODO)
-
-_To be written: austraits-api-specific architecture, key entry points, build & test, known gotchas._
+Don't duplicate that content here — edit `AGENTS.md` and this file stays correct by reference.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# austraits-api — agent guide
+
+> ⚠️ **Package-local guidance is TODO.** This stub currently only points to family-wide
+> context. Add austraits-api-specific architecture, build/test commands, and gotchas below.
+
+## Cross-package context
+
+`austraits-api` is part of the **AusTraits family**. Cross-package concerns are documented
+centrally in the **[austraits-meta](https://github.com/traitecoevo/austraits-meta)** repo —
+don't restate them here, read them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, cross-boundary artifacts, source-of-truth
+  rules, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against
+> the actual repos.
+
+## Package-local guidance (TODO)
+
+_To be written: austraits-api-specific architecture, key entry points, build & test, known gotchas._

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# austraits-api — agent & contributor guide
+
+`austraits-api` is the code behind the **AusTraits API**: an R [plumber](https://www.rplumber.io/)
+service that overlays an HTTP layer over plain R functions so AusTraits data can be subset and
+queried by taxa and trait — making the data accessible to partner websites and users of varying
+technical backgrounds.
+
+## Repo-local guidance
+
+- **Purpose:** expose AusTraits data over HTTP via plumber endpoints. The README notes development
+  is iterative, driven by partner needs.
+- **Entry point:** `api_wrapper.R` boots the service — it `plumb()`s `API.build/API examples v1.R`
+  and runs it with `pr_run(port = 8000, host = "0.0.0.0")`. The README also describes launching via
+  the **Run API** button in RStudio for interactive testing of the endpoints.
+- **Endpoint definitions:** `API.build/API examples v1.R` holds the plumber routes (annotated with
+  `#*`), including `/health-check`, `/trait-count`, `/trait-summary`, `/download-taxon-data`,
+  `/taxa-list`, `/trait-list`, `/taxa-autocomplete`, `/trait-autocomplete`, `/trait-data`, and
+  `/download-trait-data`. `API.build/API examples v1.yml` is the accompanying OpenAPI/spec file.
+- **Data prep:** `API.build/dataset_prep.R` prepares the data the endpoints serve. The served data
+  lives under `API.build/data/`, which is **git-ignored** (see `.gitignore`) — it is not committed.
+- **Usage analysis:** `API activity.R` is a standalone script for downloading and summarising the
+  API activity log (object-storage hit logs); not part of the running service.
+- **Run it:** install `plumber` (and dependencies the route file uses), then
+  `Rscript api_wrapper.R` (or `source("api_wrapper.R")`), or use RStudio's Run API button. There is
+  no `DESCRIPTION` / test suite — this is a plumber app, not an R package.
+- **Default branch:** `master`.
+
+> Heads-up: `API.build/data` is git-ignored, so a fresh clone has no data to serve — run
+> `API.build/dataset_prep.R` (or otherwise populate `API.build/data/`) before the endpoints will
+> return results.
+
+---
+
+## AusTraits family — cross-package context
+
+`austraits-api` is part of the **AusTraits family** (a subset of the
+[`traitecoevo`](https://github.com/traitecoevo) org) — here, the AusTraits API (programmatic data
+access service). Family-wide concerns are documented centrally in
+**[austraits-meta](https://github.com/traitecoevo/austraits-meta)** — don't restate them here, read
+them there:
+
+- **Start with [`AGENTS.md`](https://github.com/traitecoevo/austraits-meta/blob/main/AGENTS.md)** —
+  pipeline order, who owns what, dependency direction, source-of-truth rules, cross-boundary
+  artifacts, gotchas.
+- **[`dependencies.yml`](https://github.com/traitecoevo/austraits-meta/blob/main/dependencies.yml)** —
+  machine-readable package graph + cross-boundary artifacts.
+- **[`governance/`](https://github.com/traitecoevo/austraits-meta/tree/main/governance)** —
+  label taxonomy, board #9 conventions, release playbooks, triage.
+
+**Filing issues:** the whole family is tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9) (new issues auto-add to it). Follow
+the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md):
+pick one work-type label (`bug` / `task` / `epic`); Status and Priority are set on the board, not as
+labels.
+
+> austraits-meta is hand-maintained prose — a map, not ground truth. Verify specifics against the
+> actual repos.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ Developing the API functions will be an iterative process as we consult with the
 To run the code and test the API endpoints, click the Run API button in the top right hand corner of R studio (see image link below). A dialogue box should open up where you can test inputs and get examples of the returned data.
 
 ![image](https://user-images.githubusercontent.com/50344360/156276295-eca6e5df-0bfd-4f5a-b60f-66dc3491c6f5.png)
+
+## AusTraits family
+
+`austraits-api` is part of the **AusTraits family** of packages maintained by the
+[AusTraits](https://austraits.org) team. See **[austraits.org](https://austraits.org)** for the
+project, the data, and the people behind it.
+
+Contributing? Issues across the family are tracked on one board,
+[AusTraits #9](https://github.com/orgs/traitecoevo/projects/9), and new issues are auto-added. Please
+read the [issue & labelling guide](https://github.com/traitecoevo/austraits-meta/blob/main/governance/issue-guide.md)
+in [`austraits-meta`](https://github.com/traitecoevo/austraits-meta) — the family's cross-package
+knowledge and governance hub — before filing.


### PR DESCRIPTION
Adds the **AusTraits family** cross-package pointer to this repo, following the
[`austraits-meta`](https://github.com/traitecoevo/austraits-meta) convention.

**Structure (CLAUDE.md is a stub; AGENTS.md holds the content):**
- `.claude/CLAUDE.md` — short stub that defers to `AGENTS.md`.
- `AGENTS.md` — repo-local guidance (architecture, build & test, gotchas) **plus** an *AusTraits
  family* section pointing to austraits-meta (`AGENTS.md`, `dependencies.yml`, `governance/`) and the
  issue/board #9 guide.
- README — an *AusTraits family* section (→ [austraits.org](https://austraits.org) for the
  project/team; → austraits-meta `governance/issue-guide.md` + board #9 for contributing).

Package-local guidance is seeded from `DESCRIPTION`/`README`; cross-package concerns are linked, not
restated. Part of bootstrapping `austraits-meta`. Opened as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)